### PR TITLE
NotImplementedError on ActionDecoder uses a None variable. Replace wi…

### DIFF
--- a/models.py
+++ b/models.py
@@ -172,5 +172,5 @@ class ActionDecoder(tools.Module):
       x = self.get(f'hout', tfkl.Dense, self._size)(x)
       dist = tools.OneHotDist(x)
     else:
-      raise NotImplementedError(dist)
+      raise NotImplementedError(self._dist)
     return dist


### PR DESCRIPTION
…th the string of the passed distribution.

Minor bug fix. dist does not exist at that location in the code. Using self._dist would make the code clear if an incorrect distribution is passed.